### PR TITLE
refactor: Update ESLint configuration to include Jest plugin

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,7 @@
 import js from '@eslint/js';
 import typescriptPlugin from '@typescript-eslint/eslint-plugin';
 import typescriptParser from '@typescript-eslint/parser';
+import jest from 'eslint-plugin-jest';
 import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
@@ -14,7 +15,10 @@ export default [
     files: ['**/*.{js,jsx}', '*.js'],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: globals.browser,
+      globals: {
+        ...globals.jest,
+        ...globals.browser,
+      },
       parser: { parse },
       parserOptions: {
         ecmaVersion: 'latest',
@@ -28,12 +32,14 @@ export default [
       'react-hooks': reactHooks,
       'react-refresh': reactRefresh,
       'simple-import-sort': simpleImportSort,
+      jest,
     },
     rules: {
       ...js.configs.recommended.rules,
       ...react.configs.recommended.rules,
       ...react.configs['jsx-runtime'].rules,
       ...reactHooks.configs.recommended.rules,
+      ...jest.configs['flat/recommended'].rules,
       'react/jsx-no-target-blank': 'off',
       'react-refresh/only-export-components': [
         'warn',
@@ -47,7 +53,10 @@ export default [
     files: ['**/*.{ts,tsx}', '*.ts'],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: globals.browser,
+      globals: {
+        ...globals.jest,
+        ...globals.browser,
+      },
       parser: typescriptParser,
       parserOptions: {
         ecmaVersion: 'latest',
@@ -63,6 +72,7 @@ export default [
       'react-refresh': reactRefresh,
       '@typescript-eslint': typescriptPlugin,
       'simple-import-sort': simpleImportSort,
+      jest,
     },
     rules: {
       ...js.configs.recommended.rules,
@@ -70,6 +80,7 @@ export default [
       ...react.configs['jsx-runtime'].rules,
       ...reactHooks.configs.recommended.rules,
       ...typescriptPlugin.configs.recommended.rules,
+      ...jest.configs['flat/recommended'].rules,
       'react/jsx-no-target-blank': 'off',
       'react-refresh/only-export-components': [
         'warn',

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@typescript-eslint/parser": "^8.2.0",
         "@vitejs/plugin-react": "^4.3.1",
         "eslint": "^9.9.1",
+        "eslint-plugin-jest": "^28.8.3",
         "eslint-plugin-react": "^7.35.0",
         "eslint-plugin-react-hooks": "^5.1.0-rc.0",
         "eslint-plugin-react-refresh": "^0.4.11",
@@ -4718,6 +4719,32 @@
       },
       "peerDependenciesMeta": {
         "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-jest": {
+      "version": "28.8.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.8.3.tgz",
+      "integrity": "sha512-HIQ3t9hASLKm2IhIOqnu+ifw7uLZkIlR7RYNv7fMcEi/p0CIiJmfriStQS2LDkgtY4nyLbIZAD+JL347Yc2ETQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0",
+        "jest": "*"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "jest": {
           "optional": true
         }
       }
@@ -13866,6 +13893,15 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "eslint-plugin-jest": {
+      "version": "28.8.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.8.3.tgz",
+      "integrity": "sha512-HIQ3t9hASLKm2IhIOqnu+ifw7uLZkIlR7RYNv7fMcEi/p0CIiJmfriStQS2LDkgtY4nyLbIZAD+JL347Yc2ETQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/utils": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "eslint-plugin-react": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@typescript-eslint/parser": "^8.2.0",
     "@vitejs/plugin-react": "^4.3.1",
     "eslint": "^9.9.1",
+    "eslint-plugin-jest": "^28.8.3",
     "eslint-plugin-react": "^7.35.0",
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.11",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,7 @@
     "tests/**/*.tsx",
     "*.d.ts",
     "*.config.ts",
-    "just.config.ts"
+    "jest.config.ts"
   ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
This commit updates the ESLint configuration file (eslint.config.js) to include the Jest plugin (eslint-plugin-jest). The Jest plugin provides additional rules and configurations specific to Jest testing framework. This change allows for better linting and code analysis of Jest test files.

Related to #1